### PR TITLE
Release 2.1.0 — portable ZIP (retry: changelog entry restored)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ GitHub release, so write it for people.
 
 ## [Unreleased]
 
+### Added
+
+- **Releases now ship a portable ZIP, and that is the artifact to use.** Unpack it and run
+  `AIDemon2.exe` — no installer, no .NET runtime needed, nothing written outside
+  `%LOCALAPPDATA%\AIDemon2\`. About 42 MB, self-contained.
+
+### Fixed
+
+- **Previous releases could not be installed at all.** The MSIX shipped unsigned, and Windows
+  refuses a package with no trust chain outright — not a warning to click through, but a flat
+  refusal. `CONTRIBUTING.md` compounded this by claiming the unsigned package was "installable
+  via the bundled `Add-AppDevPackage.ps1`", which was wrong on both counts: that script is not
+  in the release, and it would not have helped. The MSIX is still published for the day a
+  certificate is available, and both files now say plainly which one to use.
+
 ## [2.0.1] - 2026-08-01
 
 ### Fixed


### PR DESCRIPTION
## What and why

Retry of #15, which merged cleanly but whose release run then failed with *"Nothing to release: the `## [Unreleased]` section of CHANGELOG.md is empty"*.

**What went wrong:** the script that edited `CHANGELOG.md` matched a pattern that no longer applied — the `[Unreleased]` section still held the 2.0.1 text at that moment — and reported success regardless of whether it changed anything. The portable-ZIP entry therefore never made it into the commit. The subsequent merge from `master` brought in the 2.0.1 promotion and left `[Unreleased]` empty, which is exactly the state the release workflow refuses to publish.

Worth noting the gate did its job: it stopped before tagging, so `v2.1.0` was never created and nothing had to be undone.

**This PR** restores the entry. `tools/Release.ps1 -Command notes` was run locally this time to confirm the notes actually render before pushing.

## The change itself (unchanged from #15)

Releases now carry a **self-contained single-file ZIP** (~42 MB). Unpack, run `AIDemon2.exe` — no installer, no .NET runtime, no administrator rights.

Previous releases could not be installed at all: the MSIX shipped unsigned, and Windows refuses a package with no trust chain outright. A ZIP rather than a bare `.exe`, because browsers block executable downloads with their own warning.

## Checklist

- [x] `dotnet build AIDemon2/AIDemon2.csproj -c Release -p:Platform=x64` succeeds
- [x] `dotnet test AIDemon2.Tests/AIDemon2.Tests.csproj` passes
- [ ] New behaviour has a test; a fixed bug has a regression test — n/a, packaging change
- [x] Changes described in `CHANGELOG.md` under `## [Unreleased]` — **verified with `Release.ps1 -Command notes` this time**
- [x] README updated if a user-visible feature changed

## Does this PR ship a release?

- [x] **Yes** — `VERSION` is `2.1.0`, tag does not exist yet